### PR TITLE
Change Template repository with new two delete methods

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,14 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Added
+
+* Add Delete by entity at Template
+
+=== Changed
+
+* Change the KeyValueTemplate method to use deleteByKey
+
 == [1.0.0-b7] - 2023-06-22
 
 === Added

--- a/api/nosql-core/src/main/java/jakarta/nosql/Template.java
+++ b/api/nosql-core/src/main/java/jakarta/nosql/Template.java
@@ -191,6 +191,22 @@ public interface Template {
     <T, K> void delete(Class<T> type, K id);
 
     /**
+     * Deletes a given entity. Deletion is performed by matching the Id.
+     *
+     * @param entity must not be {@literal null}.
+     * @throws NullPointerException when the entity is null
+     */
+    <T> void delete(T entity);
+
+    /**
+     * Deletes the given entities. Deletion of each entity is performed by matching the Id.
+     *
+     * @param entities must not be {@literal null}. Must not contain {@literal null} elements.
+     * @throws NullPointerException when either the iterable is null or contains null elements
+     */
+    <T> void delete(Iterable<? extends T> entities);
+
+    /**
      * It starts a query using the fluent-API journey. It is a mutable and non-thread-safe instance.
      *
      * @param type the entity class

--- a/api/nosql-key-value/src/main/java/jakarta/nosql/keyvalue/KeyValueTemplate.java
+++ b/api/nosql-key-value/src/main/java/jakarta/nosql/keyvalue/KeyValueTemplate.java
@@ -183,7 +183,7 @@ public interface KeyValueTemplate extends Template {
      * @param <K> the key type
      * @throws NullPointerException when the key is null
      */
-    <K> void delete(K key);
+    <K> void deleteByKey(K key);
 
     /**
      * Removes entities from keys
@@ -192,6 +192,6 @@ public interface KeyValueTemplate extends Template {
      * @param <K>  the key type
      * @throws NullPointerException when the key is null
      */
-    <K> void delete(Iterable<K> keys);
+    <K> void deleteByKey(Iterable<K> keys);
 
 }


### PR DESCRIPTION

# Changes

- Create new methods at the Template interface (delete by entity and entities)
- Break compatibility with KeyValueTemplate changing to deleteByKey.