### PR TITLE
Tck count

### DIFF
--- a/api/src/main/java/jakarta/nosql/QueryMapper.java
+++ b/api/src/main/java/jakarta/nosql/QueryMapper.java
@@ -103,7 +103,7 @@ public interface QueryMapper {
          * This method is used when you want to delete entities where the column starts with the provided prefix.
          * <pre>{@code
          * template.delete(Book.class)
-         *         .where("author").startWith("Ada")
+         *         .where("author").startsWith("Ada")
          *         .execute();
          * }</pre>
          *
@@ -111,7 +111,7 @@ public interface QueryMapper {
          * @return the {@link MapperDeleteWhere} to continue building the query
          * @throws NullPointerException when value is null
          */
-        MapperDeleteWhere startWith(String value);
+        MapperDeleteWhere startsWith(String value);
 
         /**
          * Creates a delete condition where the specified column ends with the given value.
@@ -478,11 +478,11 @@ public interface QueryMapper {
          * <p><b>Example:</b></p>
          * <pre>{@code
          * template.select(User.class)
-         *         .where("username").startWith("admin")
+         *         .where("username").startsWith("admin")
          *         .result();
          * }</pre>
          */
-        MapperWhere startWith(String value);
+        MapperWhere startsWith(String value);
 
         /**
          * Creates a condition where the specified column ends with the given suffix.

--- a/tck/src/main/java/ee/jakarta/tck/nosql/delete/DeleteBasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/delete/DeleteBasicOperationsTemplateTest.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.nosql.select;
+package ee.jakarta.tck.nosql.delete;
 
 import ee.jakarta.tck.nosql.AbstractTemplateTest;
 import ee.jakarta.tck.nosql.entities.Person;
@@ -26,8 +26,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.util.Comparator;
 import java.util.List;
 
-@DisplayName("The query execution to the basic operations on the fluent API")
-public class BasicOperationsTemplateTest extends AbstractTemplateTest {
+@DisplayName("The query execution delete with the basic operations on the fluent API")
+public class DeleteBasicOperationsTemplateTest extends AbstractTemplateTest {
 
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)
@@ -36,14 +36,16 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         entities.forEach(entity -> template.insert(entity));
 
         try {
+
             String id = entities.get(0).getId();
+            template.delete(Person.class)
+                    .where("id").eq(id).execute();
+
             List<Person> result = template.select(Person.class)
                     .where("id").eq(id)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getId().equals(id));
+            Assertions.assertThat(result.stream()).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -57,13 +59,17 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+
+            template.delete(Person.class)
+                    .where("age")
+                    .gt(age)
+                    .execute();
+
             List<Person> result = template.select(Person.class)
                     .where("age").gt(age)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getAge() > age);
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -77,13 +83,16 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+
+            template.delete(Person.class)
+                    .where("age").gte(age)
+                    .execute();
+
             List<Person> result = template.select(Person.class)
                     .where("age").gte(age)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getAge() >= age);
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -96,13 +105,15 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+
+            template.delete(Person.class)
+                    .where("age").lt(age)
+                    .execute();
             List<Person> result = template.select(Person.class)
                     .where("age").lt(age)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getAge() < age);
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -116,13 +127,14 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+
+            template.delete(Person.class).where("age").gte(age).execute();
+
             List<Person> result = template.select(Person.class)
                     .where("age").gte(age)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getAge() <= age);
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -136,13 +148,14 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var ids = entities.stream().map(Person::getId).limit(3).toList();
+
+            template.delete(Person.class).where("id").in(ids).execute();
+
             List<Person> result = template.select(Person.class)
                     .where("id").in(ids)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> ids.contains(person.getId()));
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -157,13 +170,14 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         try {
             var ageA = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
             var ageB = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(3).findFirst().orElseThrow().getAge();
+
+            template.delete(Person.class).where("age").between(ageA, ageB).execute();
+
             List<Person> result = template.select(Person.class)
                     .where("age").between(ageA, ageB)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getAge() <= ageB && person.getAge() >= ageA);
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -177,13 +191,14 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
           var namePart =  entities.get(0).getName().substring(1, 3);
+
+            template.delete(Person.class).where("name").contains(namePart).execute();
+
             List<Person> result = template.select(Person.class)
                     .where("name").contains(namePart)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getName().contains(namePart));
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -197,13 +212,14 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var namePart =  entities.get(0).getName().substring(1, 3);
+            template.delete(Person.class)
+                    .where("name").like("%" + namePart + "%")
+                    .execute();
             List<Person> result = template.select(Person.class)
                     .where("name").like("%" + namePart + "%")
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getName().contains(namePart));
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -217,13 +233,16 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var startsWith =  entities.get(0).getName().substring(0, 1);
+
+            template.delete(Person.class)
+                    .where("name").startsWith(startsWith)
+                    .execute();
+
             List<Person> result = template.select(Person.class)
                     .where("name").startsWith(startsWith)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getName().startsWith(startsWith));
+            Assertions.assertThat(result).isEmpty();
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
@@ -237,13 +256,15 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
         try {
             var startsWith =  entities.get(0).getName().substring(0, 1);
+
+            template.delete(Person.class).where("name").endsWith(startsWith).execute();
+
             List<Person> result = template.select(Person.class)
                     .where("name").endsWith(startsWith)
                     .result();
 
-            Assertions.assertThat(result)
-                    .isNotEmpty()
-                    .allMatch(person -> person.getName().startsWith(startsWith));
+            Assertions.assertThat(result).isEmpty();
+
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -212,13 +212,13 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)
     @DisplayName("Should execute basic operation with startsWith")
-    void shouldExecuteStartWith(List<Person> entities) {
+    void shouldExecuteStartsWith(List<Person> entities) {
         entities.forEach(entity -> template.insert(entity));
 
         try {
             var startsWith =  entities.get(0).getName().substring(0, 1);
             List<Person> result = template.select(Person.class)
-                    .where("name").startWith(startsWith)
+                    .where("name").startsWith(startsWith)
                     .result();
 
             Assertions.assertThat(result)

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -238,7 +238,7 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         try {
             var startsWith =  entities.get(0).getName().substring(0, 1);
             List<Person> result = template.select(Person.class)
-                    .where("name").contains(startsWith)
+                    .where("name").endsWith(startsWith)
                     .result();
 
             Assertions.assertThat(result)

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -89,4 +89,43 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         }
     }
 
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with LT")
+    void shouldExecuteLt(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").lt(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() < age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with LTE")
+    void shouldExecuteLte(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").gte(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() <= age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.util.Comparator;
 import java.util.List;
 
 @DisplayName("The query execution to the basic operations on the fluent API")
@@ -30,7 +31,7 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
 
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)
-    @DisplayName("Should insert Iterable and select with no conditions")
+    @DisplayName("Should execute basic operation with Equals")
     void shouldExecuteEq(List<Person> entities) {
         entities.forEach(entity -> template.insert(entity));
 
@@ -43,6 +44,46 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
             Assertions.assertThat(result)
                     .isNotEmpty()
                     .allMatch(person -> person.getId().equals(id));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with GT")
+    void shouldExecuteGt(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").gt(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() > age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with GTE")
+    void shouldExecuteGte(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").gte(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() >= age);
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -169,4 +169,44 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         }
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with contains")
+    void shouldExecuteContains(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+          var namePart =  entities.get(0).getName().substring(1, 3);
+            List<Person> result = template.select(Person.class)
+                    .where("name").contains(namePart)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().contains(namePart));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with Like")
+    void shouldExecuteLike(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var namePart =  entities.get(0).getName().substring(1, 3);
+            List<Person> result = template.select(Person.class)
+                    .where("name").like("%" + namePart + "%")
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().contains(namePart));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -128,4 +128,24 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         }
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with In")
+    void shouldExecuteIn(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var ids = entities.stream().map(Person::getId).limit(3).toList();
+            List<Person> result = template.select(Person.class)
+                    .where("id").in(ids)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> ids.contains(person.getId()));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -148,4 +148,25 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         }
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with between")
+    void shouldExecuteBetween(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var ageA = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            var ageB = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(3).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").between(ageA, ageB)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() <= ageB && person.getAge() >= ageA);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.nosql.select;
+
+import ee.jakarta.tck.nosql.AbstractTemplateTest;
+import ee.jakarta.tck.nosql.entities.Person;
+import ee.jakarta.tck.nosql.factories.PersonListSupplier;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+
+@DisplayName("The query execution to the basic operations on the fluent API")
+public class BasicOperationsTemplateTest extends AbstractTemplateTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions")
+    void shouldExecuteEq(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            String id = entities.get(0).getId();
+            List<Person> result = template.select(Person.class)
+                    .where("id").eq(id)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getId().equals(id));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+}

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/BasicOperationsTemplateTest.java
@@ -209,4 +209,44 @@ public class BasicOperationsTemplateTest extends AbstractTemplateTest {
         }
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with startsWith")
+    void shouldExecuteStartWith(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var startsWith =  entities.get(0).getName().substring(0, 1);
+            List<Person> result = template.select(Person.class)
+                    .where("name").startWith(startsWith)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().startsWith(startsWith));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with startsWith")
+    void shouldExecuteEndsWith(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var startsWith =  entities.get(0).getName().substring(0, 1);
+            List<Person> result = template.select(Person.class)
+                    .where("name").contains(startsWith)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().startsWith(startsWith));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectBasicOperationsCountTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectBasicOperationsCountTemplateTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.nosql.select;
+
+import ee.jakarta.tck.nosql.AbstractTemplateTest;
+import ee.jakarta.tck.nosql.entities.Person;
+import ee.jakarta.tck.nosql.factories.PersonListSupplier;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Comparator;
+import java.util.List;
+
+@DisplayName("The query execution select with the basic operations on the fluent API with count")
+public class SelectBasicOperationsCountTemplateTest extends AbstractTemplateTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with Equals")
+    void shouldExecuteEq(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            String id = entities.get(0).getId();
+            var count = template.select(Person.class)
+                    .where("id").eq(id)
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getId().equals(id)).count();
+            Assertions.assertThat(expected).isEqualTo(count);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with GT")
+    void shouldExecuteGt(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            var count = template.select(Person.class)
+                    .where("age").gt(age)
+                    .count();
+            var expected = entities.stream().filter(person -> person.getAge() > age).count();
+            Assertions.assertThat(count).isEqualTo(expected);
+
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with GTE")
+    void shouldExecuteGte(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            var count = template.select(Person.class)
+                    .where("age").gte(age)
+                    .count();
+            var expected = entities.stream().filter(person -> person.getAge() >= age).count();
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with LT")
+    void shouldExecuteLt(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+            var count = template.select(Person.class)
+                    .where("age").lt(age)
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getAge() < age).count();
+
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with LTE")
+    void shouldExecuteLte(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+            var count = template.select(Person.class)
+                    .where("age").gte(age)
+                    .count();
+            var expected = entities.stream().filter(person -> person.getAge() <= age).count();
+
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with In")
+    void shouldExecuteIn(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var ids = entities.stream().map(Person::getId).limit(3).toList();
+            var count = template.select(Person.class)
+                    .where("id").in(ids)
+                    .count();
+
+            var expected = entities.stream().filter(person -> ids.contains(person.getId())).count();
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with between")
+    void shouldExecuteBetween(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var ageA = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            var ageB = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(3).findFirst().orElseThrow().getAge();
+            var count = template.select(Person.class)
+                    .where("age").between(ageA, ageB)
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getAge() <= ageB && person.getAge() >= ageA).count();
+
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with contains")
+    void shouldExecuteContains(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+          var namePart =  entities.get(0).getName().substring(1, 3);
+            var count = template.select(Person.class)
+                    .where("name").contains(namePart)
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getName().contains(namePart)).count();
+
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with Like")
+    void shouldExecuteLike(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var namePart =  entities.get(0).getName().substring(1, 3);
+            var count = template.select(Person.class)
+                    .where("name").like("%" + namePart + "%")
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getName().contains(namePart)).count();
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with startsWith")
+    void shouldExecuteStartsWith(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var startsWith =  entities.get(0).getName().substring(0, 1);
+            var count = template.select(Person.class)
+                    .where("name").startsWith(startsWith)
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getName().startsWith(startsWith)).count();
+
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with startsWith")
+    void shouldExecuteEndsWith(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var startsWith =  entities.get(0).getName().substring(0, 1);
+            var count = template.select(Person.class)
+                    .where("name").endsWith(startsWith)
+                    .count();
+
+            var expected = entities.stream().filter(person -> person.getName().endsWith(startsWith)).count();
+            Assertions.assertThat(count).isEqualTo(expected);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+}

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectBasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectBasicOperationsTemplateTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.nosql.select;
+
+import ee.jakarta.tck.nosql.AbstractTemplateTest;
+import ee.jakarta.tck.nosql.entities.Person;
+import ee.jakarta.tck.nosql.factories.PersonListSupplier;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Comparator;
+import java.util.List;
+
+@DisplayName("The query execution to the basic operations on the fluent API")
+public class SelectBasicOperationsTemplateTest extends AbstractTemplateTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with Equals")
+    void shouldExecuteEq(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            String id = entities.get(0).getId();
+            List<Person> result = template.select(Person.class)
+                    .where("id").eq(id)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getId().equals(id));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with GT")
+    void shouldExecuteGt(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").gt(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() > age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with GTE")
+    void shouldExecuteGte(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").gte(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() >= age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with LT")
+    void shouldExecuteLt(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").lt(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() < age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with LTE")
+    void shouldExecuteLte(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var age = entities.stream().sorted(Comparator.comparing(Person::getAge).reversed()).skip(1).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").gte(age)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() <= age);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with In")
+    void shouldExecuteIn(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var ids = entities.stream().map(Person::getId).limit(3).toList();
+            List<Person> result = template.select(Person.class)
+                    .where("id").in(ids)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> ids.contains(person.getId()));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with between")
+    void shouldExecuteBetween(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var ageA = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(1).findFirst().orElseThrow().getAge();
+            var ageB = entities.stream().sorted(Comparator.comparing(Person::getAge)).skip(3).findFirst().orElseThrow().getAge();
+            List<Person> result = template.select(Person.class)
+                    .where("age").between(ageA, ageB)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getAge() <= ageB && person.getAge() >= ageA);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with contains")
+    void shouldExecuteContains(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+          var namePart =  entities.get(0).getName().substring(1, 3);
+            List<Person> result = template.select(Person.class)
+                    .where("name").contains(namePart)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().contains(namePart));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with Like")
+    void shouldExecuteLike(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var namePart =  entities.get(0).getName().substring(1, 3);
+            List<Person> result = template.select(Person.class)
+                    .where("name").like("%" + namePart + "%")
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().contains(namePart));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with startsWith")
+    void shouldExecuteStartsWith(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var startsWith =  entities.get(0).getName().substring(0, 1);
+            List<Person> result = template.select(Person.class)
+                    .where("name").startsWith(startsWith)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().startsWith(startsWith));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should execute basic operation with startsWith")
+    void shouldExecuteEndsWith(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var startsWith =  entities.get(0).getName().substring(0, 1);
+            List<Person> result = template.select(Person.class)
+                    .where("name").endsWith(startsWith)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .allMatch(person -> person.getName().startsWith(startsWith));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+}

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectBasicOperationsTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectBasicOperationsTemplateTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.util.Comparator;
 import java.util.List;
 
-@DisplayName("The query execution to the basic operations on the fluent API")
+@DisplayName("The query execution select with the basic operations on the fluent API")
 public class SelectBasicOperationsTemplateTest extends AbstractTemplateTest {
 
     @ParameterizedTest

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateTest.java
@@ -25,11 +25,29 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
 @DisplayName("The query execution exploring the classic POJO")
 public class SelectTemplateTest extends AbstractTemplateTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions as Stream")
+    void shouldInsertIterablePersonNoConditionAsStream(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            var result = template.select(Person.class).stream();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .hasSize(entities.size());
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
 
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)
@@ -44,6 +62,26 @@ public class SelectTemplateTest extends AbstractTemplateTest {
             Assertions.assertThat(result)
                     .isNotEmpty()
                     .hasSize(entities.size());
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions")
+    void shouldFindSingleResult(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            String id = entities.get(0).getId();
+            Optional<Person> result = template.select(Person.class)
+                    .where("id").eq(id)
+                    .singleResult();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .get().extracting(Person::getId).isEqualTo(id);
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateTest.java
@@ -51,8 +51,8 @@ public class SelectTemplateTest extends AbstractTemplateTest {
 
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)
-    @DisplayName("Should insert Iterable and select with no conditions and order by")
-    void shouldInsertIterablePersonNoConditionOrderBy(List<Person> entities) {
+    @DisplayName("Should insert Iterable and select with no conditions and order by asc")
+    void shouldInsertIterablePersonNoConditionOrderByAsc(List<Person> entities) {
         entities.forEach(entity -> template.insert(entity));
 
         try {
@@ -61,13 +61,37 @@ public class SelectTemplateTest extends AbstractTemplateTest {
                     .asc()
                     .result();
 
-            Assertions.assertThat(result)
+            List<String> names = result.stream().map(Person::getName).distinct().toList();
+            Assertions.assertThat(names)
                     .isNotEmpty()
-                    .hasSize(entities.size());
+                    .containsExactly(entities.stream().map(Person::getName).sorted().toArray(String[]::new));
         } catch (UnsupportedOperationException exp) {
             Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
         }
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions and order by desc")
+    void shouldInsertIterablePersonNoConditionOrderByDesc(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            List<Person> result = template.select(Person.class)
+                    .orderBy("name")
+                    .desc()
+                    .result();
+
+            List<String> names = result.stream().map(Person::getName).distinct().toList();
+            Assertions.assertThat(names)
+                    .isNotEmpty()
+                    .containsExactly(entities.stream().map(Person::getName)
+                            .sorted(Comparator.reverseOrder()).toArray(String[]::new));
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
 
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)

--- a/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/select/SelectTemplateTest.java
@@ -51,6 +51,64 @@ public class SelectTemplateTest extends AbstractTemplateTest {
 
     @ParameterizedTest
     @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions and order by")
+    void shouldInsertIterablePersonNoConditionOrderBy(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            List<Person> result = template.select(Person.class)
+                    .orderBy("name")
+                    .asc()
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .hasSize(entities.size());
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions and Limit")
+    void shouldInsertIterablePersonNoConditionLimit(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            List<Person> result = template.select(Person.class)
+                    .limit(3)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .hasSize(3);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
+    @DisplayName("Should insert Iterable and select with no conditions and Skip")
+    void shouldInsertIterablePersonNoConditionSkip(List<Person> entities) {
+        entities.forEach(entity -> template.insert(entity));
+
+        try {
+            List<Person> result = template.select(Person.class)
+                    .skip(2)
+                    .result();
+
+            Assertions.assertThat(result)
+                    .isNotEmpty()
+                    .hasSize(entities.size() - 2);
+        } catch (UnsupportedOperationException exp) {
+            Assertions.assertThat(exp).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PersonListSupplier.class)
     @DisplayName("Should insert Iterable and select with simple conditions")
     void shouldInsertIterablePerson(List<Person> entities) {
         entities.forEach(entity -> template.insert(entity));


### PR DESCRIPTION
This pull request introduces two new comprehensive test classes to the TCK for validating basic operations on the fluent API for both delete and select (with count) queries. Additionally, it updates the fluent API method names for "starts with" conditions to improve consistency and clarity.

**API Consistency Improvements:**

* Renamed the method `startWith` to `startsWith` in the `MapperDeleteNameCondition` and `MapperNameCondition` interfaces, and updated all relevant Javadoc and code samples to use the new method name for better clarity and consistency in the API. [[1]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L106-R114) [[2]](diffhunk://#diff-57961cbf24641c9153fe4284bc2e0972119ae80d95abd4e335f8529cedfe81a8L481-R485)

**Testing Enhancements:**

* Added `DeleteBasicOperationsTemplateTest` to cover and validate all basic delete operations using the fluent API, including equals, greater than, less than, between, in, contains, like, startsWith, and endsWith conditions.
* Added `SelectBasicOperationsCountTemplateTest` to test select queries with count operations, ensuring correct behavior for all basic query conditions using the fluent API.