### PR TITLE
Include sequence collection

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/nosql/basic/BasicTemplateTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/basic/BasicTemplateTest.java
@@ -17,7 +17,9 @@ package ee.jakarta.tck.nosql.basic;
 
 import ee.jakarta.tck.nosql.AbstractTemplateTest;
 import ee.jakarta.tck.nosql.entities.Person;
+import ee.jakarta.tck.nosql.entities.RecentSearches;
 import ee.jakarta.tck.nosql.factories.PersonSupplier;
+import ee.jakarta.tck.nosql.factories.RecentSearchesSupplier;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 @DisplayName("The basic template operations using a POJO entity")
@@ -116,6 +119,24 @@ class BasicTemplateTest extends AbstractTemplateTest {
     void shouldThrowExceptionWhenNullEntityUpdated() {
         Assertions.assertThatThrownBy(() -> template.update(null))
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @DisplayName("Should insert and update a collection of entities")
+    @ParameterizedTest
+    @ArgumentsSource(RecentSearchesSupplier.class)
+    void shouldInsertAndUpdateSequencedCollection(RecentSearches entity){
+        template.insert(entity);
+
+        Optional<RecentSearches> optional = template.find(RecentSearches.class, entity.getUserId());
+
+        SoftAssertions.assertSoftly(soft -> {
+           soft.assertThat(optional).isPresent();
+           var recentSearches = optional.orElseThrow();
+           soft.assertThat(recentSearches).isNotNull();
+           soft.assertThat(recentSearches.getUserId()).isNotNull();
+            soft.assertThat(recentSearches.getKeywords()).isNotNull().isNotEmpty();
+        });
+
     }
 
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
@@ -31,6 +31,8 @@ public class RecentSearches {
     @Column
     private SequencedCollection<String> keywords;
 
+    RecentSearches() {
+    }
 
     public String getUserId() {
         return userId;
@@ -60,5 +62,12 @@ public class RecentSearches {
                 "userId='" + userId + '\'' +
                 ", keywords=" + keywords +
                 '}';
+    }
+
+    public static RecentSearches of(String userId, SequencedCollection<String> keywords) {
+        RecentSearches recentSearches = new RecentSearches();
+        recentSearches.userId = userId;
+        recentSearches.keywords = keywords;
+        return recentSearches;
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
@@ -19,6 +19,7 @@ import jakarta.nosql.Column;
 import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
 
+import java.util.Objects;
 import java.util.SequencedCollection;
 
 @Entity
@@ -29,4 +30,35 @@ public class RecentSearches {
 
     @Column
     private SequencedCollection<String> keywords;
+
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public SequencedCollection<String> getKeywords() {
+        return keywords;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RecentSearches that = (RecentSearches) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(userId);
+    }
+
+    @Override
+    public String toString() {
+        return "RecentSearches{" +
+                "userId='" + userId + '\'' +
+                ", keywords=" + keywords +
+                '}';
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
@@ -15,5 +15,18 @@
  */
 package ee.jakarta.tck.nosql.entities;
 
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+import java.util.SequencedCollection;
+
+@Entity
 public class RecentSearches {
+
+    @Id
+    private String userId;
+
+    @Column
+    private SequencedCollection<String> keywords;
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/entities/RecentSearches.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.nosql.entities;
+
+public class RecentSearches {
+}

--- a/tck/src/main/java/ee/jakarta/tck/nosql/factories/RecentSearchesSupplier.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/factories/RecentSearchesSupplier.java
@@ -15,12 +15,16 @@
  */
 package ee.jakarta.tck.nosql.factories;
 
-import ee.jakarta.tck.nosql.entities.Person;
+import ee.jakarta.tck.nosql.entities.RecentSearches;
 
-public class RecentSearchesSupplier extends AbstractSupplier<Person> {
+import java.util.UUID;
+
+public class RecentSearchesSupplier extends AbstractSupplier<RecentSearches> {
 
     @Override
-    public Person get() {
-        return Person.of(faker());
+    public RecentSearches get() {
+        var userId = UUID.randomUUID().toString();
+        var keywords = faker().lorem().words(faker().number().numberBetween(1, 10));
+        return RecentSearches.of(userId, keywords);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/nosql/factories/RecentSearchesSupplier.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/factories/RecentSearchesSupplier.java
@@ -1,0 +1,11 @@
+package ee.jakarta.tck.nosql.factories;
+
+import ee.jakarta.tck.nosql.entities.Person;
+
+public class RecentSearchesSupplier extends AbstractSupplier<Person> {
+
+    @Override
+    public Person get() {
+        return Person.of(faker());
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/nosql/factories/RecentSearchesSupplier.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/factories/RecentSearchesSupplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package ee.jakarta.tck.nosql.factories;
 
 import ee.jakarta.tck.nosql.entities.Person;


### PR DESCRIPTION
This pull request adds support for testing entities with sequenced collections in the NoSQL TCK. It introduces a new `RecentSearches` entity that models a user and their recent search keywords, along with a corresponding supplier for generating test data. A new parameterized test is added to verify insert and update operations for this type of entity.

### Entity and Supplier Additions

* Added a new entity class `RecentSearches` with a `userId` and a `SequencedCollection<String>` of keywords to support testing of entities containing sequenced collections.
* Added `RecentSearchesSupplier`, a factory class for generating random `RecentSearches` instances for use in parameterized tests.

### Test Enhancements

* Updated `BasicTemplateTest.java` to import and use the new `RecentSearches` entity and its supplier. [[1]](diffhunk://#diff-b007f9ba2898ccbce2ceec6dc608f235334796e47e182c39001799eed2a4a6cfR20-R22) [[2]](diffhunk://#diff-b007f9ba2898ccbce2ceec6dc608f235334796e47e182c39001799eed2a4a6cfR31)
* Added a new parameterized test `shouldInsertAndUpdateSequencedCollection` to verify that entities with sequenced collections can be inserted and retrieved correctly.