### PR TITLE
Update test guide

### DIFF
--- a/tck/src/test/java/ee/jakarta/tck/nosql/NoSQLTypeTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/nosql/NoSQLTypeTest.java
@@ -15,59 +15,148 @@
  */
 package ee.jakarta.tck.nosql;
 
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
 class NoSQLTypeTest {
 
-    @ParameterizedTest(name = "{0} should have a flexibility level of {1}")
-    @CsvSource({
-            "KEY_VALUE, 1",
-            "COLUMN, 2",
-            "DOCUMENT, 3",
-            "GRAPH, 4",
-            "OTHER, 0"
-    })
-    public void shouldReturnCorrectFlexibility(String type, int expectedFlexibility) {
-        Assertions.assertThat(NoSQLType.valueOf(type).getFlexibility()).isEqualTo(expectedFlexibility);
-    }
-
-    @ParameterizedTest(name = "get({0}) should return {1}")
-    @CsvSource({
-            "COLUMN, COLUMN",
-            "GRAPH, GRAPH",
-            "KEY_VALUE, KEY_VALUE"
-    })
-    public void shouldReturnTypeFromValidString(String input, String expectedType) {
-        Assertions.assertThat(NoSQLType.get(input)).isEqualTo(NoSQLType.valueOf(expectedType));
-    }
-
-    @ParameterizedTest(name = "get({0}) should return the default type KEY_VALUE for invalid input")
-    @ValueSource(strings = {"INVALID_TYPE", "UNKNOWN", ""})
-    public void shouldReturnDefaultTypeForInvalidString(String input) {
-        Assertions.assertThat(NoSQLType.get(input)).isEqualTo(NoSQLType.KEY_VALUE);
-    }
-
-    @Test
-    public void shouldReturnTypeFromValidSystemProperty() {
-        System.setProperty(NoSQLType.DATABASE_TYPE_PROPERTY, "COLUMN");
-        Assertions.assertThat(NoSQLType.get()).isEqualTo(NoSQLType.COLUMN);
+    @AfterEach
+    void clearDatabaseTypeProperty() {
         System.clearProperty(NoSQLType.DATABASE_TYPE_PROPERTY);
     }
 
-    @Test
-    public void shouldReturnDefaultTypeForInvalidSystemProperty() {
-        System.setProperty(NoSQLType.DATABASE_TYPE_PROPERTY, "INVALID_TYPE");
-        Assertions.assertThat(NoSQLType.get()).isEqualTo(NoSQLType.KEY_VALUE);
-        System.clearProperty(NoSQLType.DATABASE_TYPE_PROPERTY);
+    @Nested
+    @DisplayName("When reading database type flexibility")
+    class WhenTheFlexibilityIsRead {
+
+        @ParameterizedTest(name = "{0} should have flexibility level {1}")
+        @CsvSource({
+                "KEY_VALUE, 1",
+                "COLUMN, 2",
+                "DOCUMENT, 3",
+                "GRAPH, 4",
+                "OTHER, 0"
+        })
+        @DisplayName("Should return the configured level")
+        void shouldReturnTheConfiguredLevel(String type, int expectedFlexibility) {
+
+            // Given
+            var noSQLType = NoSQLType.valueOf(type);
+
+            // When
+            var flexibility = noSQLType.getFlexibility();
+
+            // Then
+            assertThat(flexibility)
+                    .as("flexibility level for %s", type)
+                    .isEqualTo(expectedFlexibility);
+        }
     }
 
-    @Test
-    public void shouldReturnDefaultTypeWhenNoSystemPropertyIsSet() {
-        System.clearProperty(NoSQLType.DATABASE_TYPE_PROPERTY);
-        Assertions.assertThat(NoSQLType.get()).isEqualTo(NoSQLType.KEY_VALUE);
+    @Nested
+    @DisplayName("When resolving a database type by name")
+    class WhenTheTypeIsResolvedByName {
+
+        @ParameterizedTest(name = "{0} should resolve to {1}")
+        @CsvSource({
+                "COLUMN, COLUMN",
+                "document, DOCUMENT",
+                "Graph, GRAPH",
+                "KEY_VALUE, KEY_VALUE",
+                "OTHER, OTHER"
+        })
+        @DisplayName("Should return the matching type")
+        void shouldReturnTheMatchingType(String input, NoSQLType expectedType) {
+
+            // When
+            var type = NoSQLType.get(input);
+
+            // Then
+            assertThat(type)
+                    .as("database type resolved from %s", input)
+                    .isEqualTo(expectedType);
+        }
+
+        @ParameterizedTest(name = "Invalid value \"{0}\" should resolve to KEY_VALUE")
+        @ValueSource(strings = {"INVALID_TYPE", "UNKNOWN", ""})
+        @DisplayName("Should return the default type when the name is invalid")
+        void shouldReturnTheDefaultTypeWhenTheNameIsInvalid(String input) {
+
+            // When
+            var type = NoSQLType.get(input);
+
+            // Then
+            assertThat(type)
+                    .as("default database type for invalid name")
+                    .isEqualTo(NoSQLType.KEY_VALUE);
+        }
+
+        @Test
+        @DisplayName("Should reject a null name")
+        void shouldRejectANullName() {
+
+            // When / Then
+            assertThatNullPointerException()
+                    .as("null database type name")
+                    .isThrownBy(() -> NoSQLType.get(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("When resolving a database type from the system property")
+    class WhenTheTypeIsResolvedFromTheSystemProperty {
+
+        @Test
+        @DisplayName("Should return the configured type")
+        void shouldReturnTheConfiguredType() {
+
+            // Given
+            System.setProperty(NoSQLType.DATABASE_TYPE_PROPERTY, "COLUMN");
+
+            // When
+            var type = NoSQLType.get();
+
+            // Then
+            assertThat(type)
+                    .as("database type from the system property")
+                    .isEqualTo(NoSQLType.COLUMN);
+        }
+
+        @Test
+        @DisplayName("Should return the default type when the configured value is invalid")
+        void shouldReturnTheDefaultTypeWhenTheConfiguredValueIsInvalid() {
+
+            // Given
+            System.setProperty(NoSQLType.DATABASE_TYPE_PROPERTY, "INVALID_TYPE");
+
+            // When
+            var type = NoSQLType.get();
+
+            // Then
+            assertThat(type)
+                    .as("default database type for an invalid system property")
+                    .isEqualTo(NoSQLType.KEY_VALUE);
+        }
+
+        @Test
+        @DisplayName("Should return the default type when the property is absent")
+        void shouldReturnTheDefaultTypeWhenThePropertyIsAbsent() {
+
+            // When
+            var type = NoSQLType.get();
+
+            // Then
+            assertThat(type)
+                    .as("default database type without a system property")
+                    .isEqualTo(NoSQLType.KEY_VALUE);
+        }
     }
 }

--- a/tck/src/test/java/ee/jakarta/tck/nosql/entities/MoneyConverterTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/nosql/entities/MoneyConverterTest.java
@@ -16,30 +16,87 @@
 package ee.jakarta.tck.nosql.entities;
 
 import jakarta.nosql.AttributeConverter;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Currency;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 class MoneyConverterTest {
 
     private final AttributeConverter<Money, String> converter = new MoneyConverter();
 
-    @Test
-    public void shouldConvertToDatabaseColumn() {
-        Money money = new Money(Currency.getInstance("USD"), BigDecimal.valueOf(10));
-        String convert = converter.convertToDatabaseColumn(money);
-        Assertions.assertThat(convert).isEqualTo("USD 10");
+    @Nested
+    @DisplayName("When converting money to a database value")
+    class WhenTheDatabaseValueIsCreated {
+
+        @Test
+        @DisplayName("Should return the currency and amount")
+        void shouldReturnTheCurrencyAndAmount() {
+
+            // Given
+            var money = new Money(Currency.getInstance("USD"), BigDecimal.valueOf(10));
+
+            // When
+            var databaseValue = converter.convertToDatabaseColumn(money);
+
+            // Then
+            assertThat(databaseValue)
+                    .as("serialized money")
+                    .isEqualTo("USD 10");
+        }
+
+        @Test
+        @DisplayName("Should return null when money is null")
+        void shouldReturnNullWhenMoneyIsNull() {
+
+            // When
+            var databaseValue = converter.convertToDatabaseColumn(null);
+
+            // Then
+            assertThat(databaseValue)
+                    .as("serialized null money")
+                    .isNull();
+        }
     }
 
-    @Test
-    public void shouldConvertToEntityAttribute() {
-        Money money = converter.convertToEntityAttribute("USD 10");
-        SoftAssertions.assertSoftly(a -> {
-            a.assertThat(money.currency().getCurrencyCode()).isEqualTo("USD");
-            a.assertThat(money.value()).isEqualByComparingTo(BigDecimal.valueOf(10));
-        });
+    @Nested
+    @DisplayName("When converting a database value to money")
+    class WhenTheMoneyIsCreated {
+
+        @Test
+        @DisplayName("Should return the currency and amount")
+        void shouldReturnTheCurrencyAndAmount() {
+
+            // When
+            var money = converter.convertToEntityAttribute("USD 10");
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(money.currency().getCurrencyCode())
+                        .as("currency code")
+                        .isEqualTo("USD");
+                softly.assertThat(money.value())
+                        .as("money amount")
+                        .isEqualByComparingTo(BigDecimal.valueOf(10));
+            });
+        }
+
+        @Test
+        @DisplayName("Should return null when the database value is null")
+        void shouldReturnNullWhenTheDatabaseValueIsNull() {
+
+            // When
+            var money = converter.convertToEntityAttribute(null);
+
+            // Then
+            assertThat(money)
+                    .as("money converted from a null database value")
+                    .isNull();
+        }
     }
 }


### PR DESCRIPTION
This pull request refactors and enhances the unit tests for `NoSQLType` and `MoneyConverter`, improving readability, maintainability, and test coverage. The tests are now organized using nested classes with descriptive names, and additional assertions and edge case tests have been added.

**Test structure improvements:**

* Refactored both `NoSQLTypeTest` and `MoneyConverterTest` to use nested test classes and descriptive `@DisplayName` annotations, making test cases easier to understand and maintain. [[1]](diffhunk://#diff-d6823e50a470a88f2df3e51a8dfee3182ec688f92b2356f44c1950c82f2ded89L18-R160) [[2]](diffhunk://#diff-511309472485eb73d0a7a9a9a619c488745ae008104ce5ded91776e766f74329L19-R101)

**Test coverage and assertions:**

* Added tests for null handling in both `NoSQLType.get(String)` and `MoneyConverter` methods, ensuring that null inputs are handled gracefully and as expected. [[1]](diffhunk://#diff-d6823e50a470a88f2df3e51a8dfee3182ec688f92b2356f44c1950c82f2ded89L18-R160) [[2]](diffhunk://#diff-511309472485eb73d0a7a9a9a619c488745ae008104ce5ded91776e766f74329L19-R101)
* Improved assertions by switching to AssertJ's fluent assertions and soft assertions for better failure messages and grouped checks. [[1]](diffhunk://#diff-d6823e50a470a88f2df3e51a8dfee3182ec688f92b2356f44c1950c82f2ded89L18-R160) [[2]](diffhunk://#diff-511309472485eb73d0a7a9a9a619c488745ae008104ce5ded91776e766f74329L19-R101)
* Added parameterized tests to cover more input variations and edge cases, such as invalid type names and absent system properties for `NoSQLType`.
* Ensured proper cleanup of system properties after each test in `NoSQLTypeTest` to avoid test interference.