### PR TITLE
Fix flaky person age test data

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/nosql/factories/AbstractListSupplier.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/factories/AbstractListSupplier.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 abstract class AbstractListSupplier<T> extends AbstractSupplier<List<T>> {
 
-    private static final int SIZE = 6;
+    static final int SIZE = 6;
 
 
     @Override

--- a/tck/src/main/java/ee/jakarta/tck/nosql/factories/PersonListSupplier.java
+++ b/tck/src/main/java/ee/jakarta/tck/nosql/factories/PersonListSupplier.java
@@ -17,7 +17,21 @@ package ee.jakarta.tck.nosql.factories;
 
 import ee.jakarta.tck.nosql.entities.Person;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
 public class PersonListSupplier extends AbstractListSupplier<Person> {
+
+    @Override
+    public List<Person> get() {
+        Set<Integer> ages = new HashSet<>();
+        return Stream.generate(this::getEntity)
+                .filter(person -> ages.add(person.getAge()))
+                .limit(SIZE)
+                .toList();
+    }
 
     @Override
     Person getEntity() {

--- a/tck/src/test/java/ee/jakarta/tck/nosql/factories/PersonListSupplierTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/nosql/factories/PersonListSupplierTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.nosql.factories;
+
+import ee.jakarta.tck.nosql.entities.Person;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersonListSupplierTest {
+
+    @Test
+    @DisplayName("Should supply people with distinct ages")
+    void shouldSupplyPeopleWithDistinctAges() {
+
+        // Given
+        var ages = List.of(10, 10, 20, 30, 40, 50, 60).iterator();
+        var supplier = new PersonListSupplier() {
+            @Override
+            Person getEntity() {
+                var person = new Person();
+                person.setAge(ages.next());
+                return person;
+            }
+        };
+
+        // When
+        var people = supplier.get();
+
+        // Then
+        assertThat(people)
+                .extracting(Person::getAge)
+                .containsExactly(10, 20, 30, 40, 50, 60);
+    }
+}


### PR DESCRIPTION
Fixes #239.

The less-than selection test uses the second-smallest generated age as its upper bound and expects at least one result. Because `PersonListSupplier` could generate duplicate ages, the two smallest ages could be equal. In that case, the query correctly returned no results and the test failed intermittently.

This change:

- Generates persons until six distinct ages have been collected.
- Adds a deterministic regression test that forces a duplicate age and verifies it is rejected.

Testing:

- Targeted regression test passed on `main`.
- Full Maven package passed with JDK 21 and JDK 25.
- The equivalent change and regression test passed against tag `1.0.1` in a temporary worktree.
